### PR TITLE
Resolved open issues

### DIFF
--- a/ssim/ssim.py
+++ b/ssim/ssim.py
@@ -152,12 +152,18 @@ def _expand(record, date_format="%d%b%y", season=None):
     period_of_operation_from = record["period_of_operation_from"]
     if period_of_operation_from in infinity_indicators:
         if season:
+            log_text = (
+                "Found infinity indicator %s as start date -> "
+                "set to start of season %s"
+                % (period_of_operation_from, season)
+            )
+            logging.warning(log_text)
             period_of_operation_from = find_season_dates(season)[0]
         else:
             raise ValueError(
                 "Found infinity indicator "
                 + period_of_operation_from
-                + " in file, but no season specified. Pleas sepcify season. \n"
+                + " in file, but no season specified. Pleas specify season. \n"
                 + record["raw"]
             )
     else:
@@ -166,12 +172,18 @@ def _expand(record, date_format="%d%b%y", season=None):
     period_of_operation_to = record["period_of_operation_to"]
     if period_of_operation_to in infinity_indicators:
         if season:
+            log_text = (
+                "Found infinity indicator %s as end date -> "
+                "set to end of season %s"
+                % (period_of_operation_to, season)
+            )
+            logging.warning(log_text)
             period_of_operation_to = find_season_dates(season)[-1]
         else:
             raise ValueError(
                 "Found infinity indicator "
                 + period_of_operation_to
-                + " in file, but no season specified. Pleas sepcify season. \n"
+                + " in file, but no season specified. Pleas specify season. \n"
                 + record["raw"]
             )
     else:

--- a/ssim/ssim.py
+++ b/ssim/ssim.py
@@ -152,18 +152,12 @@ def _expand(record, date_format="%d%b%y", season=None):
     period_of_operation_from = record["period_of_operation_from"]
     if period_of_operation_from in infinity_indicators:
         if season:
-            log_text = (
-                "Found infinity indicator %s as start date -> "
-                "set to start of season %s"
-                % (period_of_operation_from, season)
-            )
-            logging.warning(log_text)
             period_of_operation_from = find_season_dates(season)[0]
         else:
             raise ValueError(
                 "Found infinity indicator "
                 + period_of_operation_from
-                + " in file, but no season specified. Pleas specify season. \n"
+                + " in file, but no season specified. Pleas sepcify season. \n"
                 + record["raw"]
             )
     else:
@@ -172,18 +166,12 @@ def _expand(record, date_format="%d%b%y", season=None):
     period_of_operation_to = record["period_of_operation_to"]
     if period_of_operation_to in infinity_indicators:
         if season:
-            log_text = (
-                "Found infinity indicator %s as end date -> "
-                "set to end of season %s"
-                % (period_of_operation_to, season)
-            )
-            logging.warning(log_text)
             period_of_operation_to = find_season_dates(season)[-1]
         else:
             raise ValueError(
                 "Found infinity indicator "
                 + period_of_operation_to
-                + " in file, but no season specified. Pleas specify season. \n"
+                + " in file, but no season specified. Pleas sepcify season. \n"
                 + record["raw"]
             )
     else:


### PR DESCRIPTION
The three open issues have been resolved in this pull request:
- **Trigger warning if 00XXX00 in SSIM**: in case 00XXX00 is found in SSIM files as either start or end date, a warning is triggered that the season provided as input is used to determine the required start or end date
- **Allow multiple encoding formats apart from UTF-8**: a sample of the selected input file is used to determine the encoding format of the file, before reading the full file with the found encoding format
- **Relaxing the compulsory seat order**: as some airlines deviate from SSIM standards, seat classes were left over and thereby not read by the algorithm. Instead, by focusing on provided information one is able to read all seat classes.
